### PR TITLE
Add supports for pip install -r requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ The Makefile and linker scripts are generated automatically by the build system.
 The build system can be launched by the following command and navigating the browser to [http://127.0.0.1:8000/](http://127.0.0.1:8000)
 
 
-    python3 manage.py runserver
+```
+pip install -r requirements.txt
+python3 manage.py runserver
+```
 
 
 

--- a/frankensteinWebUI/settings.py
+++ b/frankensteinWebUI/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'w3a!zu0f85+3sv_2+&!f(p&g3$b2fj9j4##&4qzy0zd_l^03i6'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["127.0.0.1"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 DATA_UPLOAD_MAX_MEMORY_SIZE = 64*1024*1024
 
 

--- a/frankensteinWebUI/settings.py
+++ b/frankensteinWebUI/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'w3a!zu0f85+3sv_2+&!f(p&g3$b2fj9j4##&4qzy0zd_l^03i6'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+ALLOWED_HOSTS = ["127.0.0.1"]
 DATA_UPLOAD_MAX_MEMORY_SIZE = 64*1024*1024
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+asgiref==3.6.0
+backports.zoneinfo==0.2.1
+capstone==4.0.2
+Django==1.11.24
+pyelftools==0.24
+pytz==2022.7
+sqlparse==0.4.3
+unicorn==2.0.1.post1


### PR DESCRIPTION
This change make dependencies installation way easier by supporting `pip install -r requirements.txt`.